### PR TITLE
fix(admin): close loading toast on success/error for announcement creation

### DIFF
--- a/app/admin/page.jsx
+++ b/app/admin/page.jsx
@@ -21,6 +21,7 @@ const AddAnnouncementPage = () => {
     if (isPending) {
       toastId = toast.loading("Adding your announcement... Just a moment!");
     } else if (formState.success) {
+      toast.dismiss(toastId);
       toast.success("Announcement added successfully!", { id: toastId });
     } else if (formState.error) {
       toast.dismiss(toastId);


### PR DESCRIPTION
Ensures the loading toast is closed before displaying the success or error message when adding an announcement on the admin page. This prevents the loading toast from staying open after the process completes.