### PR TITLE
fix(database): remove unique index causing dummy user creation issue

### DIFF
--- a/initialize_db.sql
+++ b/initialize_db.sql
@@ -56,8 +56,6 @@ CREATE TABLE IF NOT EXISTS raspberry_schedules (
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
-CREATE UNIQUE INDEX IF NOT EXISTS idx_raspberry_schedules_day_hour ON raspberry_schedules(day, hour);
-
 
 -- Insert a dummy user if it doesn't already exist
 DO $$


### PR DESCRIPTION
Removed the `idx_raspberry_schedules_day_hour` unique index from `raspberry_schedules` table creation. This fixes a bug that prevented the dummy user from being inserted into the database.